### PR TITLE
feat: add Homebrew formula + multi-platform binary release pipeline

### DIFF
--- a/.brew/README.md
+++ b/.brew/README.md
@@ -1,0 +1,78 @@
+# Homebrew Tap: greenarmor/homebrew-gesf
+
+This directory contains the Homebrew formula for GESF and the APT packaging config. The formula is hosted in a **separate repository** at `github.com/greenarmor/homebrew-gesf`.
+
+## Setup — One Time
+
+### 1. Create the tap repository
+
+```bash
+# Create a new public repo on GitHub:
+# https://github.com/new
+# Repository name: homebrew-gesf
+# Description: Homebrew tap for GESF — Compliance-as-Code CLI
+# Make it public
+
+git clone git@github.com:greenarmor/homebrew-gesf.git
+cd homebrew-gesf
+mkdir Formula
+cp /path/to/gesf/.brew/ges.rb Formula/ges.rb
+git add Formula/ges.rb
+git commit -m "Add GESF formula v1.6.1"
+git push origin main
+```
+
+### 2. After each release — update SHA256 hashes
+
+The `release-binaries.yml` workflow prints the SHA256 hashes for each binary. After the first release with binaries:
+
+```bash
+# The CI job "update-formula" will print these. Copy them into Formula/ges.rb.
+# Or compute them manually:
+curl -sL https://github.com/greenarmor/gesf/releases/download/v1.6.1/ges-darwin-arm64 | shasum -a 256
+curl -sL https://github.com/greenarmor/gesf/releases/download/v1.6.1/ges-darwin-x64 | shasum -a 256
+curl -sL https://github.com/greenarmor/gesf/releases/download/v1.6.1/ges-linux-x64 | shasum -a 256
+```
+
+Update the `sha256` fields in `Formula/ges.rb` and bump the `version` line. Push to `homebrew-gesf`.
+
+### 3. Users install
+
+```bash
+brew tap greenarmor/gesf
+brew install ges
+```
+
+## How It Works
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| Homebrew formula | `.brew/ges.rb` | Copies to `greenarmor/homebrew-gesf/Formula/ges.rb` |
+| CI workflow | `.github/workflows/release-binaries.yml` | Builds standalone binaries with `bun build --compile` on every release |
+| APT config | `.brew/nfpm.yaml` | Used by the same CI workflow to produce `.deb` packages |
+| Release notes | `.dev-logs/release-notes-v1.6.1.md` | Updated with brew/apt install instructions |
+
+## Binary Build Pipeline
+
+```
+GitHub Release published
+        │
+        ▼
+┌───────────────────────────────────────┐
+│  release-binaries.yml                 │
+│                                       │
+│  ubuntu-latest  → bun-linux-x64       │
+│  macos-latest   → bun-darwin-arm64    │
+│  macos-13       → bun-darwin-x64      │
+│                                       │
+│  1. pnpm install + build all packages │
+│  2. bun build --compile CLI           │
+│  3. Upload ges-{target} to release    │
+│  4. nfpm builds .deb (linux only)     │
+│  5. Print SHA256s for formula update  │
+└───────────────────────────────────────┘
+        │
+        ▼
+  Users: brew install ges
+  Users: dpkg -i ges_x.y.z_amd64.deb
+```

--- a/.brew/ges.rb
+++ b/.brew/ges.rb
@@ -1,0 +1,47 @@
+# Homebrew Formula for GESF (Green Engineering Standard Framework)
+#
+# Install with:
+#   brew tap greenarmor/gesf
+#   brew install ges
+#
+# This formula installs the standalone binary from GitHub Releases.
+# The CI workflow (.github/workflows/release-binaries.yml) builds and uploads
+# binaries for linux-x64, darwin-arm64, and darwin-x64 on every release.
+#
+# Repository: https://github.com/greenarmor/homebrew-gesf
+
+class Ges < Formula
+  desc "Green Engineering Standard Framework — Compliance-as-Code CLI"
+  homepage "https://github.com/greenarmor/gesf"
+  version "1.6.1"
+  license "MIT"
+
+  if OS.mac?
+    if Hardware::CPU.arm?
+      url "https://github.com/greenarmor/gesf/releases/download/v#{version}/ges-darwin-arm64"
+      sha256 "REPLACE_WITH_SHA256_DARWIN_ARM64" # brew fetch --build-from-source ges
+    else
+      url "https://github.com/greenarmor/gesf/releases/download/v#{version}/ges-darwin-x64"
+      sha256 "REPLACE_WITH_SHA256_DARWIN_X64"  # brew fetch --build-from-source ges
+    end
+  elsif OS.linux?
+    url "https://github.com/greenarmor/gesf/releases/download/v#{version}/ges-linux-x64"
+    sha256 "REPLACE_WITH_SHA256_LINUX_X64"     # brew fetch --build-from-source ges
+  end
+
+  def install
+    if OS.mac?
+      if Hardware::CPU.arm?
+        bin.install "ges-darwin-arm64" => "ges"
+      else
+        bin.install "ges-darwin-x64" => "ges"
+      end
+    elsif OS.linux?
+      bin.install "ges-linux-x64" => "ges"
+    end
+  end
+
+  test do
+    system "#{bin}/ges", "--version"
+  end
+end

--- a/.brew/nfpm.yaml
+++ b/.brew/nfpm.yaml
@@ -1,0 +1,32 @@
+# APT / .deb packaging for GESF CLI
+#
+# Built by the release-binaries.yml workflow on every GitHub Release.
+# Users install with:
+#   dpkg -i ges_1.6.1_amd64.deb
+#
+# Or add to a private APT repo for:
+#   apt install ges
+
+name: ges
+arch: amd64
+platform: linux
+version: ${GITHUB_REF_NAME#v}
+version_schema: semver
+section: devel
+priority: optional
+maintainer: greenarmor <greenarmor@live.com>
+description: |
+  Green Engineering Standard Framework — Compliance-as-Code CLI.
+  Installs GDPR, OWASP, NIST, and CIS controls as enforceable policy.
+  Includes audit engine, scoring, governance provenance, and AI inference.
+homepage: https://github.com/greenarmor/gesf
+license: MIT
+
+contents:
+  - src: ./ges-linux-x64
+    dst: /usr/local/bin/ges
+
+deb:
+  compression: xz
+  fields:
+    Bugs: https://github.com/greenarmor/gesf/issues

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,109 @@
+name: Release Binaries
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-binaries:
+    name: Build ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: bun-linux-x64
+            asset-name: ges-linux-x64
+          - os: macos-latest
+            target: bun-darwin-arm64
+            asset-name: ges-darwin-arm64
+          - os: macos-13
+            target: bun-darwin-x64
+            asset-name: ges-darwin-x64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        run: pnpm -r run build
+
+      - name: Compile standalone binary
+        run: |
+          bun build --compile \
+            --target=${{ matrix.target }} \
+            packages/cli/src/cli.ts \
+            --outfile ${{ matrix.asset-name }}
+
+      - name: Test binary
+        run: ./${{ matrix.asset-name }} --version
+
+      - name: Upload binary to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ matrix.asset-name }}
+
+  build-deb:
+    name: Build .deb package (linux-x64)
+    runs-on: ubuntu-latest
+    needs: [build-binaries]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download linux-x64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: ges-linux-x64
+
+      - name: Build .deb package
+        uses: goreleaser/nfpm@v2
+        with:
+          config: .brew/nfpm.yaml
+          target: ges_${{ github.ref_name }}_amd64.deb
+
+      - name: Upload .deb to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ges_${{ github.ref_name }}_amd64.deb
+
+  update-formula:
+    name: Update Homebrew formula SHA256s
+    runs-on: ubuntu-latest
+    needs: [build-binaries]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download all binaries
+        uses: actions/download-artifact@v4
+
+      - name: Compute SHA256s
+        id: shas
+        run: |
+          echo "darwin-arm64=$(shasum -a 256 ges-darwin-arm64/ges-darwin-arm64 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          echo "darwin-x64=$(shasum -a 256 ges-darwin-x64/ges-darwin-x64 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          echo "linux-x64=$(shasum -a 256 ges-linux-x64/ges-linux-x64 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+
+      - name: Print SHA256s (copy to homebrew-gesf formula)
+        run: |
+          echo "=== Copy these to greenarmor/homebrew-gesf Formula/ges.rb ==="
+          echo "darwin-arm64: ${{ steps.shas.outputs.darwin-arm64 }}"
+          echo "darwin-x64:   ${{ steps.shas.outputs.darwin-x64 }}"
+          echo "linux-x64:    ${{ steps.shas.outputs.linux-x64 }}"


### PR DESCRIPTION
- .brew/ges.rb: Homebrew formula for standalone binary install (copies to greenarmor/homebrew-gesf repo — users: brew tap greenarmor/gesf)
- .brew/nfpm.yaml: APT .deb packaging config for linux-x64
- .brew/README.md: tap setup guide + SHA256 lifecycle explainer
- .github/workflows/release-binaries.yml: CI workflow triggered on GitHub Release — builds standalone binaries for linux-x64, darwin-arm64, and darwin-x64 with bun build --compile, uploads as release assets, and produces a .deb package via nfpm